### PR TITLE
#8 Replace deprecated defines

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -2310,7 +2310,7 @@ int32 OutputDataToTargetFile()
 
     /* Create the standard header */
     FileHeader.ContentType = 0x63464531;
-    FileHeader.SubType = CFE_FS_TBL_IMG_SUBTYPE;
+    FileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     FileHeader.Length = sizeof(CFE_FS_Header_t);
 
     if (ScIDSpecified == TRUE)


### PR DESCRIPTION
Fixes issue #8 

Built with unit tests enabled on Linux after fix (with the OMIT DEPRECATED defined).