### PR TITLE
Fix #17, add validation for rtncode and update bracket to standard

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -131,7 +131,7 @@ CFE_TBL_File_Hdr_t  TableHeader;
 
 union Elf_Ehdr ElfHeader;
 union Elf_Shdr **SectionHeaderPtrs = NULL;
-union Elf_Shdr SectionHeaderStringTable = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+union Elf_Shdr SectionHeaderStringTable = {{ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }};
 int64 SectionHeaderStringTableDataOffset = 0;
 char  **SectionNamePtrs = NULL;
 
@@ -1367,11 +1367,18 @@ int32 OpenSrcFile(void)
 
     /* Obtain time of object file's last modification */
     RtnCode = stat(SrcFilename, &SrcFileStats);
+    if (RtnCode == 0)
+    {
+        SrcFileTimeInScEpoch = SrcFileStats.st_mtime + EpochDelta;
 
-    SrcFileTimeInScEpoch = SrcFileStats.st_mtime + EpochDelta;
-
-    if (Verbose) printf("Original Source File Modification Time: %s\n", ctime(&SrcFileStats.st_mtime));
-    if (Verbose) printf("Source File Modification Time in Seconds since S/C Epoch: %ld (0x%08lX)\n", SrcFileTimeInScEpoch, SrcFileTimeInScEpoch);
+        if (Verbose) printf("Original Source File Modification Time: %s\n", ctime(&SrcFileStats.st_mtime));
+        if (Verbose) printf("Source File Modification Time in Seconds since S/C Epoch: %ld (0x%08lX)\n", SrcFileTimeInScEpoch, SrcFileTimeInScEpoch);
+    }
+    else 
+    {
+        if (Verbose) printf("Unable to get modification time from %s", SrcFilename);
+        SrcFileTimeInScEpoch = 0;
+    }
 
     return SUCCESS;
 }


### PR DESCRIPTION
**Describe the contribution**
Fix #17. Resolve warning with flags  -Wall -std=c99 -pedantic -Wstrict-prototypes -Wwrite-strings

**Testing performed**
Steps taken to test the contribution:
1. Build 
2. Verify warning does not appear
3. Execute elf2cfetbl against table object
4. Verify *.tbl is generated
5. Execute again with DDD
6. Force RtnCode = -1
7. Verify *.tbl is generated

**Expected behavior changes**
No impact to behavior

**System(s) tested on:**
 - Hardware
 - Ubuntu 18.04.03
 - elf2cfetbl version 3.1.0, cFE 6.7.0

**Contributor Info**
Anh Van, NASA Goddard

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
