### PR TITLE
Fix #22: Clean up elf2cfetbl build logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,8 @@
 # CMake snippet for building elf2cfetbl
 #
-# WARNING: There are numerous hacks in here to get this to work,
-# however when data dictionary / electronic data sheet functionality
-# gets merged in then this all becomes moot, as tool becomes obsolete.
-# (you can build tables from text files)
-
-# cfe core, PSP, and OSAL public header files
-include_directories(${MISSION_SOURCE_DIR}/osal/src/os/inc)
-include_directories(${MISSION_SOURCE_DIR}/psp/fsw/inc)
+include_directories(${MISSION_BINARY_DIR}/inc)
+include_directories(${osal_MISSION_DIR}/src/os/inc)
 include_directories(${cfe-core_MISSION_DIR}/src/inc)
-
-# Hack: This needs to use tbl header files that are normally private to the cFE table app 
-include_directories(${cfe-core_MISSION_DIR}/src/tbl)
-
-# This uses the OSAL and PSP header files although it does not actually use the OSAL library
-# or PSP.  Therefore in order for this to work there must be at least these files to satisfy
-# the compiler when it needs to find them:
-#  osconfig.h
-#  cfe_psp_config.h
-#  psp_version.h
-include_directories(${MISSION_BINARY_DIR}/editor_inc)
-
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/inc_stubs)
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/inc_stubs/cfe_psp_config.h 
-   "/* Empty placeholder cfe_psp_config.h file */\n")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/inc_stubs/psp_version.h
-   "/* Empty placeholder psp_version.h file */\n")
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/inc_stubs)
 
 add_executable(elf2cfetbl elf2cfetbl.c)
 


### PR DESCRIPTION
Remove the now-unnecessary inclusion of CFE TBL internal definitions.
All logic in this tool is based on public include files only.

CFE ensures that the header sizes are always a multiple of 4 bytes,
so the logic to selectively byte-align is unnecessary.  CFE now
requires this to be 4-byte aligned.

Clean up all hacks in the CMake recipe, the build is now much
more straightforward when internal headers aren't being used.

**Describe the contribution**
Fixes issue #22, cleans up the build process for this tool.

_IMPORTANT_ - This depends on nasa/cfe#27 and cannot be merged/tested prior to this being merged.  This can only be cleaned up on this side once it is ensured that the internal CFE_TBL definitions are no longer required here.

Note this also removes the `-n` option to the tool, as  nasa/cfe#27 now guarantees this to be 4-byte aligned through the use of compile-time checks.  It is not possible for this option to do anything, and the code that implemented this option was depending on a symbol that was no longer available, so it was easiest and cleanest to just prune it out.


**Testing performed**
Rebuild code with sample table definitions.  Table is built successfully.

**Expected behavior changes**
No impact to behavior

**System(s) tested on:**
Ubuntu 18.04.2, 64-bit

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
