### PR TITLE
Fix #26, PATH_MAX not defined with -std=c99

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -37,7 +37,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <sys/stat.h>
-#include <limits.h>
+#include <linux/limits.h>
 #include "ELF_Structures.h"
 #include "cfe_tbl_filedef.h"
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #26 

**Testing performed**
Steps taken to test the contribution:
1. Built with -std=c99 defined, elf2cfetbl now builds

**Expected behavior changes**
None

**System(s) tested on:**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 16.04
 - Versions: master bundle with this branch

**Additional context**
None

**Contributor Info**
Jacob Hageman - NASA/GSFC
