### PR TITLE
Fix #37, termination on strncpy

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -936,13 +936,15 @@ int32 ProcessCmdLineOptions(int ArgumentCount, char *Arguments[])
         if ((Arguments[i][0] == '-') && (Arguments[i][1] == 't'))
         {
             // Extract the Table Name Override
-            strncpy(TableName, &Arguments[i][2], 38);
+            strncpy(TableName, &Arguments[i][2], sizeof(TableName)-1);
+            TableName[sizeof(TableName)-1] = 0;
             TableNameOverride = true;
         }
         else if ((Arguments[i][0] == '-') && (Arguments[i][1] == 'd'))
         {
             // Extract the Description Override
-            strncpy(Description, &Arguments[i][2], 32);
+            strncpy(Description, &Arguments[i][2], sizeof(Description)-1);
+            Description[sizeof(Description)-1] = 0;
             DescriptionOverride = true;
         }
         else if ((Arguments[i][0] == '-') && (Arguments[i][1] == 's'))


### PR DESCRIPTION
**Describe the contribution**
Fix possible non-termination of strings within command line parsing.
This generated a warning in GCC9.

Fixes #37

**Testing performed**
Build code with default config, SIMULATION=native BUILDTYPE=release on GCC 9.3.0.
Confirm successful build with no warning.

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04 LTS 64 bit

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.