### PR TITLE
Fix #45 - null terminates src/dst filenames

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1227,11 +1227,13 @@ int32 ProcessCmdLineOptions(int ArgumentCount, char *Arguments[])
         else if (!InputFileSpecified)
         {
             strncpy(SrcFilename, Arguments[i], PATH_MAX - 1);
+            SrcFilename[PATH_MAX - 1] = '\0';
             InputFileSpecified = true;
         }
         else if (!OutputFileSpecified)
         {
             strncpy(DstFilename, Arguments[i], PATH_MAX - 1);
+            DstFilename[PATH_MAX - 1] = '\0';
             OutputFileSpecified = true;
         }
         else

--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -2249,6 +2249,12 @@ int32 GetTblDefInfo(void)
         fseek(SrcFileDesc, SeekOffset, SEEK_SET);
         NumDefsRead = fread(&TblFileDef, sizeof(CFE_TBL_FileDef_t), 1, SrcFileDesc);
 
+        /* ensuring all are strings are null-terminated */
+        TblFileDef.ObjectName[sizeof(TblFileDef.ObjectName) - 1] = '\0';
+        TblFileDef.TableName[sizeof(TblFileDef.TableName) - 1] = '\0';
+        TblFileDef.Description[sizeof(TblFileDef.Description) - 1] = '\0';
+        TblFileDef.TgtFilename[sizeof(TblFileDef.TgtFilename) - 1] = '\0';
+
         if (NumDefsRead != 1)
         {
             printf("Error! Unable to read data content of '%s' from '%s'.\n", TBL_DEF_SYMBOL_NAME, SrcFilename);


### PR DESCRIPTION
**Describe the contribution**
Adds a null to the end of SrcFilename and DstFilename when using strncpy.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov