### PR TITLE
Integration Candidate: 2020-06-24

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,45 +2,48 @@
 
 This repository contains NASA's ELF to cFE Table Converter Tool (elf2cfetbl), which is a framework component of the Core Flight System.
 
-This lab application is a ground utility to convert ELF to cFE binary tables for cFS. It is intended to be located in the `tools/elf2cfetbl` subdirectory of a cFS Mission Tree.  The Core Flight System is bundled at https://github.com/nasa/cFS (which includes this tool as a submodule), which includes build and execution instructions.
+This lab application is a ground utility to convert ELF to cFE binary tables for cFS. It is intended to be located in the `tools/elf2cfetbl` subdirectory of a cFS Mission Tree. The Core Flight System is bundled at <https://github.com/nasa/cFS> (which includes this tool as a submodule), which includes build and execution instructions.
 
 See README.txt for more information.
 
 ## Version History
 
-#### Development Build: 3.1.3
-  
+### Development Build: 3.1.4
+
+- Fix string termination warnings in GCC9
+- See <https://github.com/nasa/elf2cfetbl/pull/41>
+
+### Development Build: 3.1.3
+
 - Builds for vxworks w/ 32-bit host
-- See https://github.com/nasa/elf2cfetbl/pull/40
+- See <https://github.com/nasa/elf2cfetbl/pull/40>
 
-#### Development Build: 3.1.2
-  
-- Minor bug fixes and documentation (see https://github.com/nasa/elf2cfetbl/pull/25)
+### Development Build: 3.1.2
 
-#### Development Build: 3.1.1
+- Minor bug fixes and documentation (see <https://github.com/nasa/elf2cfetbl/pull/25>)
 
-- Minor updates (see https://github.com/nasa/elf2cfetbl/pull/19)
+### Development Build: 3.1.1
 
+- Minor updates (see <https://github.com/nasa/elf2cfetbl/pull/19>)
 
-### ***OFFICIAL RELEASE: 3.1.0***
+### **_OFFICIAL RELEASE: 3.1.0_**
 
-- Minor updates (see https://github.com/nasa/elf2cfetbl/pull/13)
+- Minor updates (see <https://github.com/nasa/elf2cfetbl/pull/13>)
 - Not backwards compatible with OSAL 4.2.1
 - Released as part of cFE 6.7.0, Apache 2.0
 
-### ***OFFICIAL RELEASE: 3.0a***
+### **_OFFICIAL RELEASE: 3.0a_**
 
 - Released as part of cFE 6.6.0a, Apache 2.0
 
-NOTE - there are other parameter set management schemes used with the cFS (JSON, csv, etc) which may be more applicable for modern missions.  Contact the community as detailed below for more information.
+NOTE - there are other parameter set management schemes used with the cFS (JSON, csv, etc) which may be more applicable for modern missions. Contact the community as detailed below for more information.
 
 ## Known issues
 
-This ground utility was developed for a specific mission/configuration, and may not be applicable for general use.  The Makefile and for_build/Makefile are no longer supported or tested.
+This ground utility was developed for a specific mission/configuration, and may not be applicable for general use. The Makefile and for_build/Makefile are no longer supported or tested.
 
 ## Getting Help
 
-For best results, submit issues:questions or issues:help wanted requests at https://github.com/nasa/cFS.
+For best results, submit issues:questions or issues:help wanted requests at <https://github.com/nasa/cFS>.
 
-Official cFS page: http://cfs.gsfc.nasa.gov
-
+Official cFS page: <http://cfs.gsfc.nasa.gov>

--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 This repository contains NASA's ELF to cFE Table Converter Tool (elf2cfetbl), which is a framework component of the Core Flight System.
 
-This lab application is a ground utility to convert ELF to cFE binary tables for cFS. It is intended to be located in the `tools/elf2cfetbl` subdirectory of a cFS Mission Tree. The Core Flight System is bundled at <https://github.com/nasa/cFS> (which includes this tool as a submodule), which includes build and execution instructions.
+This lab application is a ground utility to convert ELF to cFE binary tables for cFS. It is intended to be located in the `tools/elf2cfetbl` subdirectory of a cFS Mission Tree. The Core Flight System is bundled at <https://github.com/nasa/cFS>, which includes this tool as a submodule, and includes build and execution instructions.
 
 See README.txt for more information.
 
 ## Version History
+
+### Development Build: v3.1.0+dev39
+
+- Adds a null to the end of SrcFilename and DstFilename when using strncpy.
+- Support ELF files that have all strings, including ELF section names, in one single ".strtab" section in the ELF file.
+- Version reporting now uses the version numbers defined in elf_version.h and reports build number.
+- See  <https://github.com/nasa/elf2cfetbl/pull/47>
 
 ### Development Build: 3.1.5
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ See README.txt for more information.
 
 ## Version History
 
+### Development Build: 3.1.5
+
+- Apply code style
+- See <https://github.com/nasa/elf2cfetbl/pull/44>
+
 ### Development Build: 3.1.4
 
 - Fix string termination warnings in GCC9

--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1261,7 +1261,7 @@ int32 ProcessCmdLineOptions(int ArgumentCount, char *Arguments[])
 void OutputVersionInfo(void)
 {
     printf("\nElf Object File to cFE Table Image File Conversion Tool\n");
-    printf(" Version v3.1.3\n");
+    printf(" Version v3.1.4\n");
     printf(" Built - %s %s\n\n", __DATE__, __TIME__);
 }
 

--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1273,7 +1273,7 @@ int32 ProcessCmdLineOptions(int ArgumentCount, char *Arguments[])
 void OutputVersionInfo(void)
 {
     printf("\nElf Object File to cFE Table Image File Conversion Tool\n");
-    printf(" Version v3.1.4\n");
+    printf(" Version v3.1.5\n");
     printf(" Built - %s %s\n\n", __DATE__, __TIME__);
 }
 

--- a/elf2cfetbl_version.h
+++ b/elf2cfetbl_version.h
@@ -31,7 +31,7 @@
 /*
  * Development Build Macro Definitions 
  */
-#define ELF2CFETBL_BUILD_NUMBER 36 /*!< @brief Number of commits since baseline */
+#define ELF2CFETBL_BUILD_NUMBER 39 /*!< @brief Number of commits since baseline */
 #define ELF2CFETBL_BUILD_BASELINE "v3.1.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
 
 /*

--- a/elf2cfetbl_version.h
+++ b/elf2cfetbl_version.h
@@ -18,65 +18,49 @@
 **  limitations under the License.
 */
 
-/*
- *  File: elf2cfetbl_version.h
- *
- *  Purpose:
- *  Provide version identifiers for the ELF to cFE Table Converter.
- *  See cfe documentation for version and build number and description
- */
 
+/*! @file elf2cfetbl_version.h
+ * @brief Purpose:
+ *  @details Provide version identifiers for the ELF to cFE Table Converter. @n
+ *  See @ref cfsversions for version and build number and description
+ * 
+ */
 #ifndef ELF2CFETBL_VERSION_H
 #define ELF2CFETBL_VERSION_H
 
-
-/* Development Build Macro Definitions */
-/** @brief Number of commits since baseline v3.1.0 */
-#define ELF2CFETBL_BUILD_NUMBER 36 
-#define ELF2CFETBL_BUILD_BASELINE "v3.1.0+dev"
+/*
+ * Development Build Macro Definitions 
+ */
+#define ELF2CFETBL_BUILD_NUMBER 36 /*!< @brief Number of commits since baseline */
+#define ELF2CFETBL_BUILD_BASELINE "v3.1.0+dev" /*!< @brief Development Build: git tag that is the base for the current */
 
 /*
  * Version Macro Definitions
- * These are only used for OFFICIAL release builds.
  */
-#define ELF2CFETBL_MAJOR_VERSION 3
-#define ELF2CFETBL_MINOR_VERSION 1
-#define ELF2CFETBL_REVISION      0
-#define ELF2CFETBL_MISSION_REV   0
+#define ELF2CFETBL_MAJOR_VERSION 3 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
+#define ELF2CFETBL_MINOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
+#define ELF2CFETBL_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. */
+#define ELF2CFETBL_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
 
 /*
  * Tools to construct version string
- */
-#define ELF2CFETBL_STR_HELPER(x) #x
-#define ELF2CFETBL_STR(x)        ELF2CFETBL_STR_HELPER(x)
+ */ 
+#define ELF2CFETBL_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer macros */
+#define ELF2CFETBL_STR(x)        ELF2CFETBL_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
 
-/* Development Build Format for ELF2CFETBL_VERSION */
-/* Baseling git tag + Number of commits since baseline, see elf2cfetbl_buildnumber.h */ 
+/*! @brief Development Build Version Number. 
+ * @details Baseline git tag + Number of commits since baseline. @n
+ * See @ref cfsversions for format differences between development and release versions.
+ */
 #define ELF2CFETBL_VERSION ELF2CFETBL_BUILD_BASELINE ELF2CFETBL_STR(ELF2CFETBL_BUILD_NUMBER)
 
-/* Development Build Format for ELF2CFETBL_VERSION_STRING */
+/*! @brief Development Build Version String.
+ * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest official version. @n
+ * See @ref cfsversions for format differences between development and release versions. 
+*/     
 #define ELF2CFETBL_VERSION_STRING                                                         \
     " elf2cfetbl Development Build\n"                                                     \
     " " ELF2CFETBL_VERSION " (Codename: Bootes)\n" /* Codename for current development */ \
     " Last Offical Release: elf2cfetbl v3.1.0"     /* For full support please use official release version */
-
-/* Use the following templates for Official Releases ONLY */
-  /* Official Release format for ELF2CFETBL_VERSION */
-  /* 
-    #define ELF2CFETBL_VERSION "v"               \    
-    ELF2CFETBL_STR(ELF2CFETBL_MAJOR_VERSION) "." \
-    ELF2CFETBL_STR(ELF2CFETBL_MINOR_VERSION) "." \
-    ELF2CFETBL_STR(ELF2CFETBL_REVISION) "."      \
-    ELF2CFETBL_STR(ELF2CFETBL_MISSION_REV)         
-  */
-  
-  
-  /* Official Release format for ELF2CFETBL_VERSION_STRING */
-  /*
-    #define ELF2CFETBL_VERSION_STRING "elf2cfetbl " ELF2CFETBL_VERSION
-  */
-  
-/* END TEMPLATES */
-
 
 #endif /* ELF2CFETBL_VERSION_H */


### PR DESCRIPTION
**Describe the contribution**
Fix #45 
Fix #48 
Resolve #6
Resolve #50

**Testing performed**
Bundle CI - https://github.com/nasa/cFS/pull/108/checks

**Expected behavior changes**
PR #46 -  Adds a null to the end of SrcFilename and DstFilename when using strncpy.

PR #49 - Support ELF files that have all strings, including ELF section names, in one single ".strtab" section in the ELF file.

PR #51 - Version reporting now uses the version numbers defined in `elf_version.h` and reports build number.

**System(s) tested on**
Ubuntu - CI

**Additional context**
Part of https://github.com/nasa/cFS/pull/108

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher D. Knight, NASA-ARC
Joseph Hickey, Vantage Systems, Inc.
Gerardo E. Cruz-Ortiz, NASA-GSFC