### PR TITLE
Resolve #50, Add baseline and build number to version.h

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -40,6 +40,7 @@
 #include <limits.h>
 #include "ELF_Structures.h"
 #include "cfe_tbl_filedef.h"
+#include "elf2cfetbl_version.h"
 
 #define MAX_SECTION_HDR_NAME_LEN (128)
 #define TBL_DEF_SYMBOL_NAME      "CFE_TBL_FileDef"
@@ -1281,7 +1282,7 @@ int32 ProcessCmdLineOptions(int ArgumentCount, char *Arguments[])
 void OutputVersionInfo(void)
 {
     printf("\nElf Object File to cFE Table Image File Conversion Tool\n");
-    printf(" Version v3.1.5\n");
+    printf("Version v%d.%d.%d.%d ", ELF2CFETBL_MAJOR_VERSION, ELF2CFETBL_MINOR_VERSION, ELF2CFETBL_REVISION, ELF2CFETBL_MISSION_REV);
     printf(" Built - %s %s\n\n", __DATE__, __TIME__);
 }
 

--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1281,9 +1281,7 @@ int32 ProcessCmdLineOptions(int ArgumentCount, char *Arguments[])
 
 void OutputVersionInfo(void)
 {
-    printf("\nElf Object File to cFE Table Image File Conversion Tool\n");
-    printf("Version v%d.%d.%d.%d ", ELF2CFETBL_MAJOR_VERSION, ELF2CFETBL_MINOR_VERSION, ELF2CFETBL_REVISION, ELF2CFETBL_MISSION_REV);
-    printf(" Built - %s %s\n\n", __DATE__, __TIME__);
+    printf("\n%s\n", ELF2CFETBL_VERSION_STRING);    
 }
 
 /**
@@ -1292,6 +1290,7 @@ void OutputVersionInfo(void)
 
 void OutputHelpInfo(void)
 {
+    printf("\nElf Object File to cFE Table Image File Conversion Tool (elf2cfetbl)\n\n");      
     printf("elf2cfetbl [-tTblName] [-d\"Description\"] [-h] [-v] [-V] [-s#] [-p#] [-n] \n");
     printf("           [-T] [-eYYYY:MM:DD:hh:mm:ss] [-fYYYY:MM:DD:hh:mm:ss] SrcFilename [DestDirectory]\n");
     printf("   where:\n");

--- a/elf2cfetbl_version.h
+++ b/elf2cfetbl_version.h
@@ -29,12 +29,54 @@
 #ifndef ELF2CFETBL_VERSION_H
 #define ELF2CFETBL_VERSION_H
 
+
+/* Development Build Macro Definitions */
+/** @brief Number of commits since baseline v3.1.0 */
+#define ELF2CFETBL_BUILD_NUMBER 36 
+#define ELF2CFETBL_BUILD_BASELINE "v3.1.0+dev"
+
 /*
- * Macro Definitions
+ * Version Macro Definitions
+ * These are only used for OFFICIAL release builds.
  */
 #define ELF2CFETBL_MAJOR_VERSION 3
 #define ELF2CFETBL_MINOR_VERSION 1
-#define ELF2CFETBL_REVISION      5
+#define ELF2CFETBL_REVISION      0
 #define ELF2CFETBL_MISSION_REV   0
+
+/*
+ * Tools to construct version string
+ */
+#define ELF2CFETBL_STR_HELPER(x) #x
+#define ELF2CFETBL_STR(x)        ELF2CFETBL_STR_HELPER(x)
+
+/* Development Build Format for ELF2CFETBL_VERSION */
+/* Baseling git tag + Number of commits since baseline, see elf2cfetbl_buildnumber.h */ 
+#define ELF2CFETBL_VERSION ELF2CFETBL_BUILD_BASELINE ELF2CFETBL_STR(ELF2CFETBL_BUILD_NUMBER)
+
+/* Development Build Format for ELF2CFETBL_VERSION_STRING */
+#define ELF2CFETBL_VERSION_STRING                                                         \
+    " elf2cfetbl Development Build\n"                                                     \
+    " " ELF2CFETBL_VERSION " (Codename: Bootes)\n" /* Codename for current development */ \
+    " Last Offical Release: elf2cfetbl v3.1.0"     /* For full support please use official release version */
+
+/* Use the following templates for Official Releases ONLY */
+  /* Official Release format for ELF2CFETBL_VERSION */
+  /* 
+    #define ELF2CFETBL_VERSION "v"               \    
+    ELF2CFETBL_STR(ELF2CFETBL_MAJOR_VERSION) "." \
+    ELF2CFETBL_STR(ELF2CFETBL_MINOR_VERSION) "." \
+    ELF2CFETBL_STR(ELF2CFETBL_REVISION) "."      \
+    ELF2CFETBL_STR(ELF2CFETBL_MISSION_REV)         
+  */
+  
+  
+  /* Official Release format for ELF2CFETBL_VERSION_STRING */
+  /*
+    #define ELF2CFETBL_VERSION_STRING "elf2cfetbl " ELF2CFETBL_VERSION
+  */
+  
+/* END TEMPLATES */
+
 
 #endif /* ELF2CFETBL_VERSION_H */

--- a/elf2cfetbl_version.h
+++ b/elf2cfetbl_version.h
@@ -1,0 +1,40 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+ *  File: elf2cfetbl_version.h
+ *
+ *  Purpose:
+ *  Provide version identifiers for the ELF to cFE Table Converter.
+ *  See cfe documentation for version and build number and description
+ */
+
+#ifndef ELF2CFETBL_VERSION_H
+#define ELF2CFETBL_VERSION_H
+
+/*
+ * Macro Definitions
+ */
+#define ELF2CFETBL_MAJOR_VERSION 3
+#define ELF2CFETBL_MINOR_VERSION 1
+#define ELF2CFETBL_REVISION      5
+#define ELF2CFETBL_MISSION_REV   0
+
+#endif /* ELF2CFETBL_VERSION_H */


### PR DESCRIPTION
**Describe the contribution**
Resolve #6 
Resolve #50 


**Testing performed**
None yet

**Expected behavior changes**
Version reporting now uses the version numbers defined in `elf_version.h`

**System(s) tested on**

**Additional context**


**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC