### PR TITLE
Fix #56, Squash int comparison warning

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -929,7 +929,7 @@ int32 ProcessCmdLineOptions(int ArgumentCount, char *Arguments[])
     int32     Status              = SUCCESS;
     bool      InputFileSpecified  = false;
     bool      OutputFileSpecified = false;
-    int16     i                   = 1;
+    int       i                   = 1;
     char *    EndPtr;
     uint32    MaxDay;
     struct tm FileEpochTm;


### PR DESCRIPTION
**Describe the contribution**
Fix #56 - squash int comparison warning

**Testing performed**
Build and ran cfe (uses tables built by elf2cfetbl), no issues.

**Expected behavior changes**
No longer produce the LGTM warning.  No behavior change.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main (+ cfe/osal main) + this change.

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC