### PR TITLE
Fix #58, Replace ctime with ctime_r

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1404,7 +1404,8 @@ int32 GetDstFilename(void)
 
 int32 OpenSrcFile(void)
 {
-    int RtnCode;
+    int       RtnCode;
+    char      TimeBuff[50];
 
     // Check to see if input file can be found and opened
     SrcFileDesc = fopen(SrcFilename, "r");
@@ -1422,10 +1423,11 @@ int32 OpenSrcFile(void)
         SrcFileTimeInScEpoch = SrcFileStats.st_mtime + EpochDelta;
 
         if (Verbose)
-            printf("Original Source File Modification Time: %s\n", ctime(&SrcFileStats.st_mtime));
-        if (Verbose)
+        {
+            printf("Original Source File Modification Time: %s\n", ctime_r(&SrcFileStats.st_mtime, TimeBuff));
             printf("Source File Modification Time in Seconds since S/C Epoch: %ld (0x%08lX)\n", SrcFileTimeInScEpoch,
                    SrcFileTimeInScEpoch);
+        }
     }
     else
     {


### PR DESCRIPTION
**Describe the contribution**
Fix #58 - replace ctime (which generates LGTM warning) with ctime_r

**Testing performed**
Built and ran code in verbose mode, confirmed time output

**Expected behavior changes**
Eliminate LGTM warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main (+ cfe/osal main) + this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC