### PR TITLE
Fix #91, Redo SymbolNames malloc to remove out-of-bounds write

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1882,7 +1882,6 @@ int32 GetSymbol(int32 SymbolIndex, union Elf_Sym *Symbol)
     uint64_t calculated_offset = SymbolTableDataOffset + (SymbolIndex * SymbolTableEntrySize);
     int32_t  SeekOffset        = (int32_t)calculated_offset;
     char     VerboseStr[60];
-    int32    i = 0;
 
     memset(VerboseStr, 0, sizeof(VerboseStr));
 
@@ -1928,14 +1927,11 @@ int32 GetSymbol(int32 SymbolIndex, union Elf_Sym *Symbol)
         printf("   st_name  = 0x%08x - ", get_st_name(Symbol));
     fseek(SrcFileDesc, SeekOffset, SEEK_SET);
 
-    while ((i < sizeof(VerboseStr)) && ((VerboseStr[i] = fgetc(SrcFileDesc)) != '\0'))
-    {
-        i++;
-    }
+    /* Ensure null terminated */
+    VerboseStr[sizeof(VerboseStr) - 1] = '\0';
 
-    VerboseStr[i] = '\0'; /* Just in case i=sizeof(VerboseStr) */
+    SymbolNames[SymbolIndex] = malloc(strlen(VerboseStr) + 1);
 
-    SymbolNames[SymbolIndex] = malloc(i + 1);
     strcpy(SymbolNames[SymbolIndex], VerboseStr);
 
     if ((strcmp(VerboseStr, TBL_DEF_SYMBOL_NAME) == 0) || (strcmp(&VerboseStr[1], TBL_DEF_SYMBOL_NAME) == 0))


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #91 
  - Removes `while` loop and uses `strlen` for `malloc` rather than `i` variable.

**Testing performed**
Just GitHub CI Actions so far.

**Expected behavior changes**
Logic stays the same, but the possibility of an out-of-bounds write is removed.

**Contributor Info**
Avi Weiss @thnkslprpt