### PR TITLE
Fix #86, Check return from chmod

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1436,6 +1436,7 @@ int32 OpenSrcFile(void)
 int32 OpenDstFile(void)
 {
     struct stat dststat;
+    int32       Status = SUCCESS;
 
     /* Check to see if output file can be opened and written */
     DstFileDesc = fopen(DstFilename, "w");
@@ -1451,7 +1452,15 @@ int32 OpenDstFile(void)
     {
         if (Verbose)
             printf("%s: Destination file permissions after open = 0x%X\n", DstFilename, dststat.st_mode);
-        chmod(DstFilename, dststat.st_mode & ~(S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH));
+
+        Status = chmod(DstFilename, dststat.st_mode & ~(S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH));
+
+        if (Status != 0)
+        {
+            printf("%s: Error while attempting to modify file permissions\n", DstFilename);
+            return FAILED;
+        }
+
         stat(DstFilename, &dststat);
         if (Verbose)
             printf("%s: Destination file permissions after chmod = 0x%X\n", DstFilename, dststat.st_mode);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #86 
  - Adds check for `return` value from `chmod`.
  - This PR adds a `FAILURE` return, but could also leave this out, as the updated permissions are reported after chmod as well.

**Testing performed**
GitHub CI actions (incl. Codeql Build etc.) all passing successfully excl. CodeQL-security for apparently pre-existing issues that are being flagged now.

**Expected behavior changes**
In cases of error (non-zero) `return` from `chmod` the error info will be printed and early return with FAILED will occur.

**Contributor Info**
Avi Weiss @thnkslprpt