### PR TITLE
Fix #87, Check return value of stat()

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1452,7 +1452,12 @@ int32 OpenDstFile(void)
         if (Verbose)
             printf("%s: Destination file permissions after open = 0x%X\n", DstFilename, dststat.st_mode);
         chmod(DstFilename, dststat.st_mode & ~(S_IRGRP | S_IWGRP | S_IXGRP | S_IROTH | S_IWOTH | S_IXOTH));
-        stat(DstFilename, &dststat);
+
+        if (stat(DstFilename, &dststat) != 0)
+        {
+            printf("%s: Error retrieving file status after chmod\n", DstFilename);
+        }
+
         if (Verbose)
             printf("%s: Destination file permissions after chmod = 0x%X\n", DstFilename, dststat.st_mode);
     }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #87 
  - Adds a check for the return value of `stat` in case of error return, and prints an error message.
    - Does not return `FAILURE`, as the `chmod` may well have been successful, and following this there is only an informational message (about the file permissions).

**Testing performed**
GitHub CI actions (incl. Codeql Build etc.) all passing successfully excl. CodeQL-security for apparently pre-existing issues that are being flagged now.

**Expected behavior changes**
No impact on behavior.
Adds error message for an (unlikely) error return from `stat()`.

**Contributor Info**
Avi Weiss @thnkslprpt