### PR TITLE
Fix #126, Move variables declared mid-function to the top

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -2256,9 +2256,10 @@ int32 GetStringFromMap(char *Result, ElfStrMap *Map, int32 Key)
 
 int32 GetTblDefInfo(void)
 {
-    int32  Status      = SUCCESS;
-    uint32 SeekOffset  = 0;
-    int32  NumDefsRead = 0;
+    int32    Status      = SUCCESS;
+    uint32   SeekOffset  = 0;
+    int32    NumDefsRead = 0;
+    uint64_t calculated_offset;
 
     /* Read the data to be used to format the CFE File and Table Headers */
     if ((get_st_size(SymbolPtrs[TblDefSymbolIndex]) != sizeof(CFE_TBL_FileDef_t)) &&
@@ -2271,8 +2272,8 @@ int32 GetTblDefInfo(void)
     else
     {
         /* fseek expects a long int, sh_offset and st_value are uint64 for elf64 */
-        uint64_t calculated_offset = get_sh_offset(SectionHeaderPtrs[get_st_shndx(SymbolPtrs[TblDefSymbolIndex])]) +
-                                     get_st_value(SymbolPtrs[TblDefSymbolIndex]);
+        calculated_offset = get_sh_offset(SectionHeaderPtrs[get_st_shndx(SymbolPtrs[TblDefSymbolIndex])]) +
+                            get_st_value(SymbolPtrs[TblDefSymbolIndex]);
         SeekOffset = (uint32_t)(calculated_offset);
         if (SeekOffset != calculated_offset)
         {
@@ -2327,11 +2328,12 @@ int32 GetTblDefInfo(void)
 
 int32 LocateAndReadUserObject(void)
 {
-    int32  Status     = SUCCESS;
-    int32  i          = 0;
-    int32  j          = 0;
-    uint32 SeekOffset = 0;
-    uint8  AByte;
+    int32    Status     = SUCCESS;
+    int32    i          = 0;
+    int32    j          = 0;
+    uint32   SeekOffset = 0;
+    uint8    AByte;
+    uint64_t calculated_offset;
 
     /* Search the symbol table for the user defined object */
     if (Verbose)
@@ -2424,9 +2426,8 @@ int32 LocateAndReadUserObject(void)
         else
         {
             /* Locate data associated with symbol */
-            uint64_t calculated_offset =
-                get_sh_offset(SectionHeaderPtrs[get_st_shndx(SymbolPtrs[UserObjSymbolIndex])]) +
-                get_st_value(SymbolPtrs[UserObjSymbolIndex]);
+            calculated_offset = get_sh_offset(SectionHeaderPtrs[get_st_shndx(SymbolPtrs[UserObjSymbolIndex])]) +
+                                get_st_value(SymbolPtrs[UserObjSymbolIndex]);
             SeekOffset = (uint32_t)(calculated_offset);
             if (SeekOffset != calculated_offset)
             {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #126 
  - A couple stray variables that were declared mid-function were moved to the top of their respective functions.

**Testing performed**
GitHub CI actions (incl. Codeql Build etc.) all passing successfully excl. CodeQL-security for apparently pre-existing issues that are being flagged now.

**Expected behavior changes**
All variables declared top of function as per cFS conventions/guidelines.

**Contributor Info**
Avi Weiss @thnkslprpt