### PR TITLE
Fix #133, Update references to CFE_FS_Header_t time members

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -2527,13 +2527,13 @@ int32 OutputDataToTargetFile()
 
     if (EnableTimeTagInHeader)
     {
-        FileHeader.TimeSeconds    = SrcFileTimeInScEpoch;
-        FileHeader.TimeSubSeconds = 0;
+        FileHeader.FileCreateTime.Seconds    = SrcFileTimeInScEpoch;
+        FileHeader.FileCreateTime.Subseconds = 0;
     }
     else
     {
-        FileHeader.TimeSeconds    = 0;
-        FileHeader.TimeSubSeconds = 0;
+        FileHeader.FileCreateTime.Seconds    = 0;
+        FileHeader.FileCreateTime.Subseconds = 0;
     }
 
     memset(FileHeader.Description, 0, CFE_FS_HDR_DESC_MAX_LEN);
@@ -2558,8 +2558,8 @@ int32 OutputDataToTargetFile()
         SwapUInt32(&FileHeader.SpacecraftID);
         SwapUInt32(&FileHeader.ProcessorID);
         SwapUInt32(&FileHeader.ApplicationID);
-        SwapUInt32(&FileHeader.TimeSeconds);
-        SwapUInt32(&FileHeader.TimeSubSeconds);
+        SwapUInt32(&FileHeader.FileCreateTime.Seconds);
+        SwapUInt32(&FileHeader.FileCreateTime.Subseconds);
     }
 
     /* Create the standard cFE Table Header */
@@ -2596,8 +2596,8 @@ int32 OutputDataToTargetFile()
     fwrite(&FileHeader.SpacecraftID, sizeof(uint32), 1, DstFileDesc);
     fwrite(&FileHeader.ProcessorID, sizeof(uint32), 1, DstFileDesc);
     fwrite(&FileHeader.ApplicationID, sizeof(uint32), 1, DstFileDesc);
-    fwrite(&FileHeader.TimeSeconds, sizeof(uint32), 1, DstFileDesc);
-    fwrite(&FileHeader.TimeSubSeconds, sizeof(uint32), 1, DstFileDesc);
+    fwrite(&FileHeader.FileCreateTime.Seconds, sizeof(uint32), 1, DstFileDesc);
+    fwrite(&FileHeader.FileCreateTime.Subseconds, sizeof(uint32), 1, DstFileDesc);
     fwrite(&FileHeader.Description[0], sizeof(FileHeader.Description), 1, DstFileDesc);
 
     fwrite(&TableHeader.Reserved, sizeof(uint32), 1, DstFileDesc);


### PR DESCRIPTION
**Describe the contribution**
- Fixes #133 
  - References to the `CFE_FS_Header_t` file create time members are updated to go through to the `CFE_TIME_SysTime_t` substruct.

**Testing performed**
GitHub CodeqL tasks failing to build because this goes along with updates to cFE: https://github.com/nasa/cFE/pull/2246

Local testing confirms all working together successfully when both changes implemented together. 100% of tests passing and net coverage unaffected.
![Screenshot 2023-04-03 09 35 59](https://user-images.githubusercontent.com/9024662/229385655-b6e0bd83-660d-4e09-91a9-013bae009e1d.png)
![Screenshot 2023-04-03 09 35 33](https://user-images.githubusercontent.com/9024662/229385660-6f91514b-ba77-43fb-9c83-50b069feaa4c.png)

**Expected behavior changes**
No change to behavior.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt