### PR TITLE
Fix #129, Reduce cyclomatic complexity of GetElfHeader

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -59,6 +59,7 @@ int32 GetSrcFilename(void);
 int32 GetDstFilename(void);
 int32 OpenSrcFile(void);
 int32 OpenDstFile(void);
+int32 checkELFFileMagicNumber(void);
 int32 GetElfHeader(void);
 void  SwapElfHeader(void);
 int32 GetSectionHeader(int32 SectionIndex, union Elf_Shdr *SectionHeader);
@@ -1464,6 +1465,18 @@ int32 OpenDstFile(void)
  *
  */
 
+int32 checkELFFileMagicNumber(void)
+{
+    if (get_e_ident(&ElfHeader, EI_MAG0) != ELFMAG0 || get_e_ident(&ElfHeader, EI_MAG1) != ELFMAG1 ||
+        get_e_ident(&ElfHeader, EI_MAG2) != ELFMAG2 || get_e_ident(&ElfHeader, EI_MAG3) != ELFMAG3)
+        return FAILED;
+    return SUCCESS;
+}
+
+/**
+ *
+ */
+
 int32 GetElfHeader(void)
 {
     int32  Status      = SUCCESS;
@@ -1493,20 +1506,15 @@ int32 GetElfHeader(void)
     }
 
     if (Verbose)
-        printf("ELF Header:\n");
-    if (Verbose)
-        printf("   e_ident[EI_MAG0..3] = 0x%02x,%c%c%c\n", get_e_ident(&ElfHeader, EI_MAG0),
-               get_e_ident(&ElfHeader, EI_MAG1), get_e_ident(&ElfHeader, EI_MAG2), get_e_ident(&ElfHeader, EI_MAG3));
+    {
+        printf("ELF Header:\n"
+               "   e_ident[EI_MAG0..3] = 0x%02x,%c%c%c\n",
+               get_e_ident(&ElfHeader, EI_MAG0), get_e_ident(&ElfHeader, EI_MAG1), get_e_ident(&ElfHeader, EI_MAG2),
+               get_e_ident(&ElfHeader, EI_MAG3));
+    }
 
     /* Verify the ELF file magic number */
-    if (get_e_ident(&ElfHeader, EI_MAG0) != ELFMAG0)
-        Status = FAILED;
-    if (get_e_ident(&ElfHeader, EI_MAG1) != ELFMAG1)
-        Status = FAILED;
-    if (get_e_ident(&ElfHeader, EI_MAG2) != ELFMAG2)
-        Status = FAILED;
-    if (get_e_ident(&ElfHeader, EI_MAG3) != ELFMAG3)
-        Status = FAILED;
+    Status = checkELFFileMagicNumber();
 
     if (Status == FAILED)
     {


### PR DESCRIPTION
**Describe the contribution**
- Fixes #129 
This change reduces the cyclomatic complexity by 5. The changes specifically condense extraneous "Verbose" if statements for printing header as well as extraneous status assignments when checking the elf magic number.

**Testing performed**
None

**Expected behavior changes**
No expected impact to behavior.

**System(s) tested on**
 - OS: Ubuntu 22.04

**Additional context**
The cyclomatic complexity for this function still remains above the recommended 15, however the code is relatively clean and follows a pretty straightforward process. If desired, further reduction of cylomatic complexity by 8 can be achieved by creating new functions for the [processor class type](https://github.com/nasa/elf2cfetbl/blob/46b29f82c76429be97687203f75f4b1b25227c60/elf2cfetbl.c#L1521-L1547) verification and [data encoding type](https://github.com/nasa/elf2cfetbl/blob/46b29f82c76429be97687203f75f4b1b25227c60/elf2cfetbl.c#L1559-L1589) verification switch/case.

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
