### PR TITLE
Fix #139, updating ELF2CFETBL to use new versioning system.

### DIFF
--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -34,6 +34,8 @@
 #include <limits.h>
 #include "ELF_Structures.h"
 #include "cfe_tbl_filedef.h"
+#include "cfe_version.h"
+#include "cfe_config.h"
 #include "elf2cfetbl_version.h"
 
 #define MAX_SECTION_HDR_NAME_LEN (128)
@@ -1264,7 +1266,12 @@ int32 ProcessCmdLineOptions(int ArgumentCount, char *Arguments[])
 
 void OutputVersionInfo(void)
 {
-    printf("\n%s\n", ELF2CFETBL_VERSION_STRING);
+    char VersionString[ELF2CFETBL_CFG_MAX_VERSION_STR_LEN];
+
+    CFE_Config_GetVersionString(VersionString, ELF2CFETBL_CFG_MAX_VERSION_STR_LEN, "elf2cfetbl",
+        ELF2CFETBL_VERSION, ELF2CFETBL_BUILD_CODENAME, ELF2CFETBL_LAST_OFFICIAL);
+
+    printf("\n%s\n", VersionString);
 }
 
 /**

--- a/elf2cfetbl_version.h
+++ b/elf2cfetbl_version.h
@@ -28,16 +28,22 @@
 /*
  * Development Build Macro Definitions
  */
-#define ELF2CFETBL_BUILD_NUMBER 36 /*!< @brief Number of commits since baseline */
-#define ELF2CFETBL_BUILD_BASELINE \
-    "v3.3.0-rc4" /*!< @brief Development Build: git tag that is the base for the current */
+#define ELF2CFETBL_BUILD_NUMBER     36 /*!< @brief Number of commits since baseline */
+#define ELF2CFETBL_BUILD_BASELINE   "equuleues-rc1" /*!< @brief Development Build: git tag that is the base for the current */
+#define ELF2CFETBL_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define ELF2CFETBL_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
 #define ELF2CFETBL_MAJOR_VERSION 3  /*!< @brief Major version number */
 #define ELF2CFETBL_MINOR_VERSION 1  /*!< @brief Minor version number */
-#define ELF2CFETBL_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define ELF2CFETBL_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define ELF2CFETBL_LAST_OFFICIAL "v3.1.0"
 
 /*!
  * @brief Mission revision.
@@ -61,13 +67,12 @@
  */
 #define ELF2CFETBL_VERSION ELF2CFETBL_BUILD_BASELINE ELF2CFETBL_STR(ELF2CFETBL_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
- * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Max Version String length.
+ * 
+ * Maximum length that an elf2cfetbl version string can be.
+ * 
  */
-#define ELF2CFETBL_VERSION_STRING                                                        \
-    " elf2cfetbl Development Build\n"                                                    \
-    " " ELF2CFETBL_VERSION " (Codename: Draco)\n" /* Codename for current development */ \
-    " Last Official Release: elf2cfetbl v3.1.0"   /* For full support please use official release version */
+#define ELF2CFETBL_CFG_MAX_VERSION_STR_LEN 256
 
 #endif /* ELF2CFETBL_VERSION_H */


### PR DESCRIPTION
**Describe the contribution**
Fixes #139.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "ELF2CFETBL_BUILD_DEV_CYCLE" macro has been defined
4. Version String has been removed, and all references to it replaced with the Build Baseline/Codename

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC