### PR TITLE
Open Source Draco Release

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -2,12 +2,20 @@ name: "CodeQL Analysis"
 
 on:
   push:
+    branches:
+      - dev
+      - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
 
 jobs:
   codeql:
     name: Codeql
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
-    with: 
+    with:
       component-path: tools/elf2cfetbl
       make: 'make -C build/tools/elf2cfetbl'

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -2,8 +2,11 @@ name: Format Check
 
 # Run on all push and pull requests
 on:
-  push:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   format-check:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,7 +3,15 @@ name: Static Analysis
 # Run on all push and pull requests
 on:
   push:
+    branches:
+      - dev
+      - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  workflow_dispatch:
 
 jobs:
 

--- a/ELF_Structures.h
+++ b/ELF_Structures.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/SampleTblImg.c
+++ b/SampleTblImg.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *

--- a/elf2cfetbl.c
+++ b/elf2cfetbl.c
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -2505,7 +2505,7 @@ int32 LocateAndReadUserObject(void)
  *
  */
 
-int32 OutputDataToTargetFile()
+int32 OutputDataToTargetFile(void)
 {
     int32 Status = SUCCESS;
     uint8 AByte  = 0;

--- a/elf2cfetbl_version.h
+++ b/elf2cfetbl_version.h
@@ -1,7 +1,7 @@
 /************************************************************************
- * NASA Docket No. GSC-18,719-1, and identified as “core Flight System: Bootes”
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
- * Copyright (c) 2020 United States Government as represented by the
+ * Copyright (c) 2023 United States Government as represented by the
  * Administrator of the National Aeronautics and Space Administration.
  * All Rights Reserved.
  *
@@ -28,22 +28,22 @@
 /*
  * Development Build Macro Definitions
  */
-#define ELF2CFETBL_BUILD_NUMBER     22 /*!< @brief Number of commits since baseline */
-#define ELF2CFETBL_BUILD_BASELINE   "equuleues-rc1" /*!< @brief Development Build: git tag that is the base for the current */
-#define ELF2CFETBL_BUILD_DEV_CYCLE  "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
-#define ELF2CFETBL_BUILD_CODENAME   "Equuleus" /**< @brief: Development: Code name for the current build */
+#define ELF2CFETBL_BUILD_NUMBER     0 /*!< @brief Number of commits since baseline */
+#define ELF2CFETBL_BUILD_BASELINE   "v7.0.0" /*!< @brief Development Build: git tag that is the base for the current */
+#define ELF2CFETBL_BUILD_DEV_CYCLE  "v7.0.0" /**< @brief Development: Release name for current development cycle */
+#define ELF2CFETBL_BUILD_CODENAME   "Draco" /**< @brief: Development: Code name for the current build */
 
 /*
  * Version Macros, see \ref cfsversions for definitions.
  */
-#define ELF2CFETBL_MAJOR_VERSION 3  /*!< @brief Major version number */
-#define ELF2CFETBL_MINOR_VERSION 1  /*!< @brief Minor version number */
+#define ELF2CFETBL_MAJOR_VERSION 7  /*!< @brief Major version number */
+#define ELF2CFETBL_MINOR_VERSION 0  /*!< @brief Minor version number */
 #define ELF2CFETBL_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
 
 /**
  * @brief Last official release.
  */
-#define ELF2CFETBL_LAST_OFFICIAL "v3.1.0"
+#define ELF2CFETBL_LAST_OFFICIAL "v7.0.0"
 
 /*!
  * @brief Mission revision.
@@ -52,7 +52,7 @@
  * Values 1-254 are reserved for mission use to denote patches/customizations as needed. NOTE: Reserving 0 and 0xFF for
  * cFS open-source development use (pending resolution of nasa/cFS#440)
  */
-#define ELF2CFETBL_MISSION_REV 0xFF
+#define ELF2CFETBL_MISSION_REV 0x0
 
 /*
  * Tools to construct version string

--- a/scripts/add_cfe_tables_impl.cmake
+++ b/scripts/add_cfe_tables_impl.cmake
@@ -24,6 +24,12 @@
 # of the target from targets.cmake and TABLE_FQNAME reflects the first
 # parameter to this function.
 #
+
+# This interface target gives a hook where the user can add any other compile
+# definitions or build options to the tables, by calling target_compile_definitions
+# or target_include_directories, etc.
+add_library(cfe-platform-table-build INTERFACE)
+
 function(do_add_cfe_tables_impl TABLE_FQNAME)
 
     cmake_parse_arguments(ADDTBL_ARG "" "APP_NAME;TARGET_NAME;INSTALL_SUBDIR" "" ${ARGN})
@@ -132,9 +138,10 @@ function(do_add_cfe_tables_impl TABLE_FQNAME)
     # before passing to elf2cfetbl.  It is roundabout but it works.
     add_library(${TABLE_LIBNAME} STATIC EXCLUDE_FROM_ALL ${TABLE_SELECTED_SRCS})
     target_compile_definitions(${TABLE_LIBNAME} PRIVATE
+        CFE_TABLE_BUILD
         CFE_CPU_NAME=${ADDTBL_ARG_TARGET_NAME}
     )
-    target_link_libraries(${TABLE_LIBNAME} ${TABLE_DEPENDENCIES})
+    target_link_libraries(${TABLE_LIBNAME} cfe-platform-table-build ${TABLE_DEPENDENCIES})
 
 
 endfunction(do_add_cfe_tables_impl)


### PR DESCRIPTION
[NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"](https://github.com/nasa/elf2cfetbl/pull/151/commits/aef73a7b3f85c66c99e28d93e3b1d3b06dc72f37)
Batch update of latest cFS software release

Reflects commit df97d952129828b68659dab1d04960a74089e0ca from NASA internal development repo