### PR TITLE
Part cFS/workflows#122, Add Internal Workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,13 @@
+name: Add Issue or PR to Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened, ready_for_review, converted_to_draft]
+
+jobs:
+  add-to-project:
+    name: Add issue or pull request to project
+    uses: nasa/cFS/.github/workflows/add-to-project-reusable.yml@dev
+    secrets: inherit


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/PSP/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Part of an internal issue cFS/workflows#122

**Testing performed**

[Add to project](https://github.com/arielswalker/FM/actions/runs/24804197737?pr=1) tested in this [PR](https://github.com/arielswalker/FM/pull/1)

**Expected behavior changes**
Add internal workflows

**System(s) tested on**
GitHub Actions

**Additional context**
Relies on this [PR ](https://github.com/nasa/cFS/pull/970)that includes files needed on dev that these workflows call. In that PR, it is noted that someone with privileges need to add an org level secret for the add to project workflow to run successfully. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH. 